### PR TITLE
quote user-supplied assembly strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -941,7 +941,7 @@ function parseTestAsm (source, line) {
         tests.push(t);
         break;
       case 'a':
-        t.cmd = 'e cfg.bigendian=' + t.endianess + ';' + 'pa ' + asm;
+        t.cmd = 'e cfg.bigendian=' + t.endianess + ';' + '"pa ' + asm + '"';
         t.expect = expect;
         t.name = filename + ': "' + asm + '" => ' + expect + colors.blue(' (assemble)');
         tests.push(t);


### PR DESCRIPTION
in db/asm tests, the user could insert r2 reserved characters into the
assembly strings (like '@') that would not be passed to the assembler.