### PR TITLE
--to-eof: Convert tests from <<KEYWORD to <<EOF

### DIFF
--- a/bin/r2r.js
+++ b/bin/r2r.js
@@ -42,7 +42,7 @@ const args = process.argv.slice(2).map(_ => {
 const delims = /['"%]/;
 
 main(minimist(args, {
-  boolean: ['v', 'verbose', 'i', 'interactive', 'l', 'list', 'debase64', 'format'],
+  boolean: ['v', 'verbose', 'i', 'interactive', 'l', 'list', 'debase64', 'format', 'to-eof'],
   string: ['g', 'grep']
 }));
 
@@ -64,7 +64,9 @@ function main (argv) {
  --debase64
        debase64 tests
  --format
-       format tests (i.e. add blank lines between tests)`);
+       format tests (i.e. add blank lines between tests)
+ --to-eof
+       convert >>KEYWORD to >>EOF`);
     rl.close();
     return 0;
   }


### PR DESCRIPTION
Done in node-r2r because:
1. node-r2r works.
1. There is code for previous use cases that are similar.
1. This is supposed to be one-use only so there's no need to clutter up r2r.v.