### PR TITLE
Remove end newline before checking test output

### DIFF
--- a/index.js
+++ b/index.js
@@ -970,7 +970,7 @@ function parseTestAsm (source, line) {
 }
 
 function removeEndNewline (str) {
-  return (str[str.length - 1] === '\n') ? str.slice(0, -1) : str;
+  return str.endsWith('\n') ? str.slice(0, -1) : str;
 }
 
 function debase64 (msg) {

--- a/index.js
+++ b/index.js
@@ -681,13 +681,21 @@ class NewRegressions {
     /* Check test output, if it's the same, the test passes */
     if (test.check === undefined) {
       if (test.expect !== undefined) {
+        test.expect = removeEndNewline(test.expect);
+        test.stdout = removeEndNewline(test.stdout);
         test.stdoutFail = (test.expect64 || test.expect64 === undefined)
           ? test.expect.trim() !== test.stdout.trim()
           : test.expect !== test.stdout;
       } else {
         test.stdoutFail = false;
       }
-      test.stderrFail = test.expectErr !== undefined ? test.expectErr !== test.stderr : false;
+      if (test.expectErr !== undefined) {
+        test.expectErr = removeEndNewline(test.expectErr);
+        test.stderr = removeEndNewline(test.stderr);
+        test.stderrFail = test.expectErr !== test.stderr;
+      } else {
+        test.stderrFail = false;
+      }
       test.passes = !test.stdoutFail && !test.stderrFail;
     } else {
       test.check(test);
@@ -959,6 +967,10 @@ function parseTestAsm (source, line) {
     }
   }
   return tests;
+}
+
+function removeEndNewline (str) {
+  return (str[str.length - 1] === '\n') ? str.slice(0, -1) : str;
 }
 
 function debase64 (msg) {


### PR DESCRIPTION
For the test conversions based on https://github.com/radareorg/radare2/pull/15835#issuecomment-575643162 to work with current r2r, it needs to disregard any end newline.