### PR TITLE
Fix autofix of EXPECT_ERR=<<EOF when test.stderr is 0 or 1 line

### DIFF
--- a/bin/r2r.js
+++ b/bin/r2r.js
@@ -412,45 +412,43 @@ function fixTest (test, next) {
               output += 'EOF\n';
             }
           } else {
-            output += 'EXPECT=<<EOF\n' + test.stdout + '\nEOF\n';
+            output += 'EXPECT=<<EOF\n' + test.stdout +
+              (test.stdout === '' || test.stdout.endsWith('\n') ? '' : '\n') + 'EOF\n';
           }
         } else if (line.startsWith('EXPECT_ERR=')) {
-          if ((test.stderr.match(/\n/g) || []).length > 1) {
-            const val = line.substring(11);
-            const valTrim = val.trim();
-            let endString = null;
-            if (valTrim.startsWith('<<')) {
-              endString = valTrim.substring(2);
+          const val = line.substring(11);
+          const valTrim = val.trim();
+          let endString = null;
+          if (valTrim.startsWith('<<')) {
+            endString = valTrim.substring(2);
+            i++;
+            while (!lines[i].startsWith(endString)) {
               i++;
-              while (!lines[i].startsWith(endString)) {
+            }
+            if (endString !== 'EOF') {
+              i--;
+            }
+          } else {
+            const delim = valTrim.charAt(0);
+            if (delims.test(delim)) {
+              const startDelim = val.indexOf(delim);
+              const endDelim = val.indexOf(delim, startDelim + 1);
+              if (endDelim === -1) {
                 i++;
-              }
-              if (endString !== 'EOF') {
-                i--;
-              }
-            } else {
-              const delim = valTrim.charAt(0);
-              if (delims.test(delim)) {
-                const startDelim = val.indexOf(delim);
-                const endDelim = val.indexOf(delim, startDelim + 1);
-                if (endDelim === -1) {
+                while (lines[i].indexOf(delim) === -1) {
                   i++;
-                  while (lines[i].indexOf(delim) === -1) {
-                    i++;
-                  }
                 }
               }
             }
-            if (test.stderr.endsWith('\n') && endString !== null) {
-              output += 'EXPECT_ERR=<<' + endString + '\n' + test.stderr;
-              if (endString === 'EOF') {
-                output += 'EOF\n';
-              }
-            } else {
-              output += 'EXPECT_ERR=<<EOF\n' + test.stderr + '\nEOF\n';
+          }
+          if (test.stderr.endsWith('\n') && endString !== null) {
+            output += 'EXPECT_ERR=<<' + endString + '\n' + test.stderr;
+            if (endString === 'EOF') {
+              output += 'EOF\n';
             }
           } else {
-            output += 'EXPECT_ERR=' + test.stderr + (test.stderr.length === 0 ? '\n' : '');
+            output += 'EXPECT_ERR=<<EOF\n' + test.stderr +
+              (test.stderr === '' || test.stderr.endsWith('\n') ? '' : '\n') + 'EOF\n';
           }
         } else {
           output += line + '\n';


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr ensures that an actual

```
EXPECT_ERR=<<EOF
EOF
```

is not autofixed to

```
EXPECT_ERR=
EOF
```

or

```
EXPECT_ERR=<<EOF

EOF
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

 1. Do something like
```
CMDS=cmd
EXPECT=<<EOF
EOF
EXPECT_ERR=<<EOF
EOF
```
with an appropriate `cmd`.

 2. Force an error from that `cmd` and autofix.
 3. Revert what was done in the previous step and autofix.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

See description.
