### PR TITLE
Improve "unexpected end-of-file" error msg to include line and source

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,11 +370,16 @@ class NewRegressions {
             if (endString !== 'EOF') {
               this.throwError('End token must be "EOF", got "' + endString + '" instead', i, source);
             }
+            let start_i = i;
             test.cmdScript = '';
             i++;
-            while (!lines[i].startsWith(endString)) {
+            while (lines[i] !== undefined && !lines[i].startsWith(endString)) {
               test.cmdScript += lines[i] + '\n';
               i++;
+            }
+            if (lines[i] === undefined) {
+              throw new Error('Unexpected end-of-file in CMDS -- did you forget a ' + endString +
+                              ' for line ' + (start_i + 1) + ' at ' + source + '?');
             }
             if (endString !== 'EOF') {
               i--;
@@ -400,6 +405,7 @@ class NewRegressions {
             if (endString !== 'EOF') {
               this.throwError('End token must be "EOF", got "' + endString + '" instead', i, source);
             }
+            let start_i = i;
             test.expectEndString = endString;
             test.expect = '';
             i++;
@@ -408,7 +414,8 @@ class NewRegressions {
               i++;
             }
             if (lines[i] === undefined) {
-              throw new Error('Unexpected EOF in EXPECT -- did you forget a ' + endString + '?');
+              throw new Error('Unexpected end-of-file in EXPECT -- did you forget a ' + endString +
+                              ' for line ' + (start_i + 1) + ' at ' + source + '?');
             }
             if (endString !== 'EOF') {
               i--;
@@ -423,6 +430,7 @@ class NewRegressions {
             if (endString !== 'EOF') {
               this.throwError('End token must be "EOF", got "' + endString + '" instead', i, source);
             }
+            let start_i = i;
             test.expectErrEndString = endString;
             test.expectErr = '';
             i++;
@@ -431,7 +439,8 @@ class NewRegressions {
               i++;
             }
             if (lines[i] === undefined) {
-              throw new Error('Unexpected EOF in EXPECT_ERR -- did you forget a ' + endString + '?');
+              throw new Error('Unexpected end-of-file in EXPECT_ERR -- did you forget a ' + endString +
+                              ' for line ' + (start_i + 1) + ' at ' + source + '?');
             }
             if (endString !== 'EOF') {
               i--;


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr improves the "unexpected end-of-file" error message to include line and source.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The following at the end of `tools/r2`:

```
NAME=radare2 -i -Q with missing script
FILE=-
CMDS=<<EOF
# Should not hang
!radare2 -i script/missing.r2 -NQ -
EOF
EXPECT=<<EOF
EOF
EXPECT_ERR=<<EOF
Script 'script/missing.r2' not found.
RUN
```

should result in something like the following:

![unexpected_eof](https://user-images.githubusercontent.com/12002672/77158599-9c8d2080-6ade-11ea-803e-da6f6f247a43.png)

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

See description.
